### PR TITLE
Move resolution to config setting and upgrade to 1080p.

### DIFF
--- a/assets/javascripts/dashing-angular.js
+++ b/assets/javascripts/dashing-angular.js
@@ -49,7 +49,10 @@ dashing.showGridsterInstructions = function() {
 
 $(function(){ //DOM Ready
   dashing.widget_margins = [5, 5];
-  dashing.widget_base_dimensions = [300, 360];
+  dashing.widget_base_dimensions = [
+    (dimensions[0] - 60) / 4,
+    (dimensions[1] - 30) / 2,
+  ];
   dashing.numColumns = 4;
 
   contentWidth = (dashing.widget_base_dimensions[0] + dashing.widget_margins[0] * 2) * dashing.numColumns

--- a/config.yml.sample
+++ b/config.yml.sample
@@ -25,4 +25,6 @@ jenkins:
   user: ''
   password: ''
 
-
+dimensions:
+  width: 1920
+  height: 1080

--- a/dashboards/layout.erb
+++ b/dashboards/layout.erb
@@ -8,6 +8,14 @@
 
   <title><%= yield_content(:title) %></title>
 
+  <!--Set the dimensions for Javascript to use -->
+  <script type="text/javascript">
+    dimensions = [
+      <%= settings.dimensions[:width] %>,
+      <%= settings.dimensions[:height] %>,
+    ];
+  </script>
+
   <!--Google fonts for making things pretty-->
   <link href='http://fonts.googleapis.com/css?family=Montserrat' rel='stylesheet' type='text/css'>
 


### PR DESCRIPTION
Change resolution (which was previously hardcoded as 1280x720) to a configuration setting, and allow fenestra to automatically resize the widgets to match the provided dimensions. Values are currently set to default to 1920x1080, the size of the screen the OSL will be using for Fenestra.

Make sure you add the dimension property (you can just copy it from the `config.yml.sample` file) before testing.