### PR TITLE
Replace manual requests with Octokit API in commit job.

### DIFF
--- a/jobs/commits.rb
+++ b/jobs/commits.rb
@@ -5,38 +5,32 @@ require 'octokit'
 projects = settings.projects || []
 
 SCHEDULER.every '1h' do
-    client = Octokit::Client.new(:access_token => settings.github['token'])
-    user = client.user
-    user.login
-    name = projects.first['repo']
-    url_base = "https://api.github.com/repos/" + projects.first['repo']
-    # Put together the branches url
-    branches_url = URI(url_base + "/git/refs/heads/" + projects.first['branch'])
-    latest_sha = latest_committer = commit_message = commit_date = nil
-	# Use the branches URL to get the latest commit sha for the branch
-    Net::HTTP.start(branches_url.host, branches_url.port, :use_ssl => (branches_url.scheme == 'https')) do |http|
-		response = http.request(Net::HTTP::Get.new(branches_url.request_uri))
-		data = JSON.parse(response.body)
-		latest_sha = data['object']['sha']
-	end
+  client = Octokit::Client.new(:access_token => settings.github['token'])
 
-	# Commit URL
-	commit_url = URI(url_base + "/commits/" + latest_sha)
-	Net::HTTP::start(commit_url.host, commit_url.port, :use_ssl => commit_url.scheme == 'https') do |http|
-        response = http.request(Net::HTTP::Get.new(commit_url.request_uri))
-        data = JSON.parse(response.body)
-        latest_committer = data['commit']['committer']['name']
-        commit_message = data['commit']['message']
-        commit_message = commit_message.split[0...15].join(' ')
-    	commit_date = Time.parse(data['commit']['committer']['date']).strftime("%a %b %e %Y")
-	end
+  project = projects.first['name']
 
-    send_event('commits', { project:
-                            {name: name,
-                             committer: latest_committer,
-                             commit_message: commit_message,
-                             date: commit_date
-							}
-                          })
-    projects.rotate!
+  latest_sha = latest_committer = commit_message = commit_date = nil
+
+  # SHA hash
+  data = client.ref(project, 'heads/' + projects.first['branch'])
+	latest_sha = data['object']['sha']
+
+	# Commit
+  data = client.git_commit(project, latest_sha)
+  latest_committer = data['committer']['name']
+  commit_message = data['message']
+  commit_message = commit_message.split[0...15].join(' ')
+  commit_date = Time.parse(data['committer']['date']).strftime('%a %b %e %Y')
+
+  send_event('commits',
+    {
+      project: {
+        name: name,
+        committer: latest_committer,
+        commit_message: commit_message,
+        date: commit_date
+			}
+    }
+  )
+  projects.rotate!
 end


### PR DESCRIPTION
<!--
  This is a guideline for what a PR should look like.
  Feel free to modify it to fit your specific needs.

  Please list the issue this fixes in the PR
-->

## Changes in this PR.
<!--
  Please include a list of all things this PR will accomplish
  Use the checkbox syntax to show what is done and what is yet to be completed.
  This gives context to the diff.
-->

The commits and languages jobs currently manually execute their (unauthenticated) requests to the GitHub API, despite the fact that the Octokit library is included.

- [X] Replace all requests using Net::HTTP, which causes really high rate limiting due to requests not being authenticated, with much simpler Octokit requests, which have a much simpler API, less bloat, built-in error handling, and the authentication we were already using.

This fix is only for commits, as languages were already fixed in #40.

## Testing this PR.
<!--
  Please include a list of explicit instructions for testing this PR.
  If the instructions are 'run `make test`' say that,
  If they are more complicated be thorough.
-->

1. Set the commits job to run e.g. every 30 seconds, and run fenestra.

### Expected Output.
<!--
  Please insert either a description of what should happen when testing
  your PR or a code-block with terminal output.
-->

Watch as your code *doesn't* break from being rate-limited.

@osuosl/devs