### PR TITLE
Round hours in TimeSync widget to nearest.

### DIFF
--- a/jobs/timesync.rb
+++ b/jobs/timesync.rb
@@ -54,7 +54,7 @@ SCHEDULER.every '1h' do
     user_times = Hash.new
     times.each do |time|
         # We want the duration in hours, not seconds
-        duration = time['duration'].fdiv(3600).round
+        duration = time['duration'].fdiv(3600)
         # If the key doesn't exist, make it, else update it
         if user_times.key?(time['user'])
             user_times[time['user']] = user_times[time['user']] + duration
@@ -66,8 +66,9 @@ SCHEDULER.every '1h' do
     # Sort the users by total time worked and get the top 10
     top_users = user_times.sort_by{|name, time| time}.reverse[0..10]
     # Get their display name instead of their username
-    top_users.each do |user|
+    top_users.each do |user, time|
         user[0] = ts.get_users(user[0])[0]['display_name']
+        time = time.round
     end
 
     # Get the total times for each project
@@ -111,7 +112,7 @@ SCHEDULER.every '1h' do
     total_times = Hash.new
     times.each do |time|
         # Hours, not seconds
-        duration = time['duration'] / 3600
+        duration = time['duration'].fdiv(3600)
         # Add the times up based on day
         days.each do |day|
             if time['date_worked'] == day
@@ -130,7 +131,7 @@ SCHEDULER.every '1h' do
     days.each do |day|
         total_times.each do |time|
             if time[0] == day
-                full_times[day] = time[1]
+                full_times[day] = time[1].round
             end
         end
         if !full_times.key?(day)

--- a/jobs/timesync.rb
+++ b/jobs/timesync.rb
@@ -54,7 +54,7 @@ SCHEDULER.every '1h' do
     user_times = Hash.new
     times.each do |time|
         # We want the duration in hours, not seconds
-        duration = time['duration'] / 3600
+        duration = time['duration'].fdiv(3600).round
         # If the key doesn't exist, make it, else update it
         if user_times.key?(time['user'])
             user_times[time['user']] = user_times[time['user']] + duration

--- a/jobs/timesync.rb
+++ b/jobs/timesync.rb
@@ -149,6 +149,7 @@ SCHEDULER.every '1h' do
         :font_color => '#000',
         :background_colors => ['#12b0c5', '#12b0c5']
     }
+    time_graph.y_axis_increment = 1
     # Make the labels for the graph
     i = 0
     days.each do |day|

--- a/jobs/timesync.rb
+++ b/jobs/timesync.rb
@@ -67,7 +67,7 @@ SCHEDULER.every '1h' do
     top_users = user_times.sort_by{|name, time| time}.reverse[0..10]
     # Get their display name instead of their username
     top_users.each do |user, time|
-        user[0] = ts.get_users(user[0])[0]['display_name']
+        user = ts.get_users(user)[0]['display_name']
         time = time.round
     end
 
@@ -131,7 +131,7 @@ SCHEDULER.every '1h' do
     days.each do |day|
         total_times.each do |time|
             if time[0] == day
-                full_times[day] = time[1].round
+                full_times[day] = time[1]
             end
         end
         if !full_times.key?(day)


### PR DESCRIPTION
<!--
  This is a guideline for what a PR should look like.
  Feel free to modify it to fit your specific needs.

  Please list the issue this fixes in the PR
-->
Fixes #52.

## Changes in this PR.
<!--
  Please include a list of all things this PR will accomplish
  Use the checkbox syntax to show what is done and what is yet to be completed.
  This gives context to the diff.
-->

- [X] Use floating-point division to remove round-down errors from hour calculations
- [X] Perform round-to-nearest rounding at the end of calculations for minimal error

## Testing this PR.
<!--
  Please include a list of explicit instructions for testing this PR.
  If the instructions are 'run `make test`' say that,
  If they are more complicated be thorough.
-->

1. Run fenestra with a small interval in the timesync widget for testing.
2. Enter a time into the timesync server with a duration like "3h45m", greater than half an hour.
3. Then add another time, with a duration of "1h30m".

### Expected Output.
<!--
  Please insert either a description of what should happen when testing
  your PR or a code-block with terminal output.
-->

1. The widget will display "4h", properly rounding your time.
2. The widget will display "5h", showing that it correctly rounded at the *end* of calculations (otherwise it would show "6h").

@osuosl/devs