### PR TITLE
Fix rounding on TimeSync user list.

### DIFF
--- a/jobs/timesync.rb
+++ b/jobs/timesync.rb
@@ -4,7 +4,7 @@ require 'rimesync'
 require 'net/http'
 require 'webmock'
 
-SCHEDULER.every '1h' do
+SCHEDULER.every '1h', first_in: '10s' do
 
     # Auth with timesync through rimesync
     ts = TimeSync.new(baseurl=settings.timesync['url'])
@@ -66,9 +66,9 @@ SCHEDULER.every '1h' do
     # Sort the users by total time worked and get the top 10
     top_users = user_times.sort_by{|name, time| time}.reverse[0..10]
     # Get their display name instead of their username
-    top_users.each do |user, time|
-        user = ts.get_users(user)[0]['display_name']
-        time = time.round
+    top_users.each do |user|
+        user[0] = ts.get_users(user[0])[0]['display_name']
+        user[1] = user[1].round
     end
 
     # Get the total times for each project


### PR DESCRIPTION
<!--
  This is a guideline for what a PR should look like.
  Feel free to modify it to fit your specific needs.

  Please list the issue this fixes in the PR
-->
Fixes bug leftover from #53. Somehow I failed to catch this before I merged that PR.

## Changes in this PR.
<!--
  Please include a list of all things this PR will accomplish
  Use the checkbox syntax to show what is done and what is yet to be completed.
  This gives context to the diff.
-->

As it turns out, if you take the key-value pair of a Hash in an ``each`` call, you *can* modify it (as we were doing), but if you take the key and the value separately, modifications don't stick around.

That is:

``` ruby
dict = {a: 1, b: 2, c: 3}
dict.each do |pair|
    pair[0] = pair[0] + 'z'
    pair[1] = pair[1] + 3
end
```

Will properly result in ``{az: 4, bz: 5, cz: 6}``, whereas:

``` ruby
dict = {a: 1, b: 2, c: 3}
dict.each do |key, val|
    key = key + 'z'
    val = val + 3
end
```

Will result in no changes to the Hash whatsoever.

## Testing this PR.
<!--
  Please include a list of explicit instructions for testing this PR.
  If the instructions are 'run `make test`' say that,
  If they are more complicated be thorough.
-->

1. Run fenestra.

### Expected Output.
<!--
  Please insert either a description of what should happen when testing
  your PR or a code-block with terminal output.
-->
See the user time list properly round the times, rather than leave a Float.

@osuosl/devs